### PR TITLE
[PRM-393]: added VAT unpaid content and lpp calculation link

### DIFF
--- a/app/viewmodels/IndexPageHelper.scala
+++ b/app/viewmodels/IndexPageHelper.scala
@@ -116,11 +116,19 @@ class IndexPageHelper @Inject()(p: views.html.components.p,
     }
   }
 
-  def getContentBasedOnLatePaymentPenaltiesFromModel (etmpData: ETMPPayload)(implicit messages: Messages, user: User[_]): Html= {
-    if (etmpData.latePaymentPenalties.getOrElse(List.empty[LatePaymentPenalty]).isEmpty){
+  def getContentBasedOnLatePaymentPenaltiesFromModel(etmpData: ETMPPayload)(implicit messages: Messages, user: User[_]): Html = {
+    if (etmpData.latePaymentPenalties.getOrElse(List.empty[LatePaymentPenalty]).isEmpty) {
       p(content = stringAsHtml(messages("lpp.penaltiesSummary.noPaymentPenalties")))
     } else {
-      p(content = html(stringAsHtml(""))) //TODO: for non-empty latePaymentPenalties
+      if (etmpData.latePaymentPenalties.get.map(_.financial.outstandingAmountDue).sum > 0) {
+        html(
+          p(content = html(stringAsHtml(messages("lpp.penaltiesSummary.unpaid")))),
+          p(link(link = "#", messages("lpp.penaltiesSummary.howLppCalculated.link", messages("site.opensInNewTab"))))
+        )
+      } else {
+        p(content = html(stringAsHtml("")))
+        p(link(link = "#", messages("lpp.penaltiesSummary.howLppCalculated.link", messages("site.opensInNewTab"))))
+      }
     }
   }
 

--- a/conf/messages
+++ b/conf/messages
@@ -66,6 +66,8 @@ lsp.onThreshold.link = Show me how to bring this account up to date
 # LPP Content
 # -------------------------------------------
 lpp.penaltiesSummary.noPaymentPenalties = There are no late payment penalties.
+lpp.penaltiesSummary.unpaid = The earlier your client pays their VAT, the lower their penalties and interest will be.
+lpp.penaltiesSummary.howLppCalculated.link = Find out how late payment penalties are calculated {0}
 
 common.pageTitle = {0} - {1} - GOV.UK
 

--- a/conf/messages
+++ b/conf/messages
@@ -66,7 +66,7 @@ lsp.onThreshold.link = Show me how to bring this account up to date
 # LPP Content
 # -------------------------------------------
 lpp.penaltiesSummary.noPaymentPenalties = There are no late payment penalties.
-lpp.penaltiesSummary.unpaid = The earlier your client pays their VAT, the lower their penalties and interest will be.
+lpp.penaltiesSummary.unpaid = The earlier you pay your VAT, the lower your penalties and interest will be.
 lpp.penaltiesSummary.howLppCalculated.link = Find out how late payment penalties are calculated {0}
 
 common.pageTitle = {0} - {1} - GOV.UK

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -66,6 +66,8 @@ lsp.onThreshold.link = Show me how to bring this account up to date
 # LPP Content
 # -------------------------------------------
 lpp.penaltiesSummary.noPaymentPenalties = There are no late payment penalties.
+lpp.penaltiesSummary.unpaid = The earlier your client pays their VAT, the lower their penalties and interest will be.
+lpp.penaltiesSummary.howLppCalculated.link = Find out how late payment penalties are calculated {0}
 
 common.pageTitle = {0} - {1} - GOV.UK
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -66,7 +66,7 @@ lsp.onThreshold.link = Show me how to bring this account up to date
 # LPP Content
 # -------------------------------------------
 lpp.penaltiesSummary.noPaymentPenalties = There are no late payment penalties.
-lpp.penaltiesSummary.unpaid = The earlier your client pays their VAT, the lower their penalties and interest will be.
+lpp.penaltiesSummary.unpaid = The earlier you pay your VAT, the lower your penalties and interest will be.
 lpp.penaltiesSummary.howLppCalculated.link = Find out how late payment penalties are calculated {0}
 
 common.pageTitle = {0} - {1} - GOV.UK

--- a/test/assets/messages/IndexMessages.scala
+++ b/test/assets/messages/IndexMessages.scala
@@ -50,6 +50,10 @@ object IndexMessages {
 
   val noActivePaymentPenalty = "There are no late payment penalties."
 
+  val unpaidVATText = "The earlier your client pays their VAT, the lower their penalties and interest will be."
+
+  val howLppCalculatedLinkText = "Find out how late payment penalties are calculated (opens in a new tab)"
+
   def multiActivePenaltyPoints(amountOfPoints: Int, amountOfLateSubmissions: Int) = s"You have $amountOfPoints penalty points for submitting $amountOfLateSubmissions VAT Returns late."
 
   def multiAgentActivePenaltyPoints(amountOfPoints: Int, amountOfLateSubmissions: Int) = s"Your client has $amountOfPoints penalty points for submitting $amountOfLateSubmissions VAT Returns late."

--- a/test/assets/messages/IndexMessages.scala
+++ b/test/assets/messages/IndexMessages.scala
@@ -50,7 +50,7 @@ object IndexMessages {
 
   val noActivePaymentPenalty = "There are no late payment penalties."
 
-  val unpaidVATText = "The earlier your client pays their VAT, the lower their penalties and interest will be."
+  val unpaidVATText = "The earlier you pay your VAT, the lower your penalties and interest will be."
 
   val howLppCalculatedLinkText = "Find out how late payment penalties are calculated (opens in a new tab)"
 

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -89,7 +89,7 @@ trait SpecBase extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
     0.0,
     4,
     Seq.empty[PenaltyPoint],
-    Option(Seq.empty[LatePaymentPenalty])
+    Some(Seq.empty[LatePaymentPenalty])
   )
 
   val sampleComplianceData: CompliancePayload = CompliancePayload(


### PR DESCRIPTION
With outstanding VAT
![Screenshot 2021-07-14 at 14 06 36](https://user-images.githubusercontent.com/56401572/125627114-19b03b14-5f26-4778-8f44-9596ad5725fd.png)

No outstanding VAT
![Screenshot 2021-07-14 at 14 08 06](https://user-images.githubusercontent.com/56401572/125627330-77432902-8668-4c8c-ade6-389b55ee1818.png)
