### PR TITLE
[PRM-1427] Removed 'additional' from LPP2 summary card

### DIFF
--- a/app/views/components/v2/summaryCardLPP.scala.html
+++ b/app/views/components/v2/summaryCardLPP.scala.html
@@ -83,11 +83,7 @@
     <header class="app-summary-card__header">
         <h3 class="app-summary-card__title">
             @{
-                if(summaryCard.isAdditionalPenalty) {
-                    messages("summaryCard.header.financialAdditionalPenalty", CurrencyFormatter.parseBigDecimalNoPaddedZeroToFriendlyValue(summaryCard.amountDue))
-                } else {
-                    messages("summaryCard.header.financialNoNumber", CurrencyFormatter.parseBigDecimalNoPaddedZeroToFriendlyValue(summaryCard.amountDue))
-                }
+                messages("summaryCard.header.financialNoNumber", CurrencyFormatter.parseBigDecimalNoPaddedZeroToFriendlyValue(summaryCard.amountDue))
             }
         </h3>
         <div class="app-summary-card__tag">

--- a/it/controllers/IndexControllerISpec.scala
+++ b/it/controllers/IndexControllerISpec.scala
@@ -1133,7 +1133,7 @@ class IndexControllerISpec extends IntegrationSpecCommonBase {
       val request = controller.onPageLoad()(fakeRequest)
       status(request) shouldBe Status.OK
       val parsedBody = Jsoup.parse(contentAsString(request))
-      parsedBody.select("#late-payment-penalties section header h3").get(0).text shouldBe "£123.45 additional penalty"
+      parsedBody.select("#late-payment-penalties section header h3").get(0).text shouldBe "£123.45 penalty"
       parsedBody.select("#late-payment-penalties section header strong").get(0).text shouldBe "paid"
       val summaryCardBody = parsedBody.select(" #late-payment-penalties .app-summary-card__body").first()
       summaryCardBody.select("dt").get(0).text shouldBe "Penalty type"

--- a/test/views/components/v2/LatePaymentPenaltySummaryCardSpec.scala
+++ b/test/views/components/v2/LatePaymentPenaltySummaryCardSpec.scala
@@ -234,11 +234,11 @@ class LatePaymentPenaltySummaryCardSpec extends SpecBase with ViewBehaviours {
       implicit val docWithAdditionalPenaltyTenthsOfPence: Document = asDocument(summaryCardHtml.apply(summaryCardModelForAdditionalPenaltyPaidWithTenths))
 
       "display the penalty amount" in {
-        docWithAdditionalPenalty.select("h3").text() shouldBe "£123.45 additional penalty"
+        docWithAdditionalPenalty.select("h3").text() shouldBe "£123.45 penalty"
       }
 
       "display the penalty amount (with padded zero for whole tenths)" in {
-        docWithAdditionalPenaltyTenthsOfPence.select("h3").text() shouldBe "£123.40 additional penalty"
+        docWithAdditionalPenaltyTenthsOfPence.select("h3").text() shouldBe "£123.40 penalty"
       }
 
       "display the View calculation link" in {


### PR DESCRIPTION
<img width="818" alt="Screenshot 2022-06-13 at 08 57 07" src="https://user-images.githubusercontent.com/86231805/173306749-668734c4-0909-45b9-bcb7-5e5215336d9f.png">
