### PR TITLE
[PRM-2562] - Removed cannot appeal and view calculation elements from LPP when appealed successfully

### DIFF
--- a/app/views/components/details.scala.html
+++ b/app/views/components/details.scala.html
@@ -16,11 +16,12 @@
 
 @this(govukDetails: GovukDetails)
 
-@(summary: String, content: Html)
+@(summary: String, content: Html, detailsClasses: Option[String] = None)
 
 @govukDetails(
     Details(
-        summary = HtmlContent(summary),
-        content = HtmlContent(content)
+      summary = HtmlContent(summary),
+      content = HtmlContent(content),
+      classes = detailsClasses.getOrElse("")
     )
 )

--- a/app/views/components/summaryCardLPP.scala.html
+++ b/app/views/components/summaryCardLPP.scala.html
@@ -43,13 +43,14 @@
 }
 
 @calculationContent = {
-    <a class="govuk-link" href="@{
+    <a class="govuk-link calculation-link" href="@{
         controllers.routes.CalculationController.onPageLoad(summaryCard.principalChargeReference, summaryCard.penaltyCategory.toString).url
     }">
     @messages("summaryCard.viewCalculation") <span class="govuk-visually-hidden">@messages("summaryCard.viewCalculation.aria.label.lpp.change", messages(s"summaryCard.appealLink.aria.label.lpp.vatPaid.${summaryCard.penaltyCategory}"), summaryCard.dueDate
         )</span>
     </a>
 }
+
 @appealContent = {
     @if(summaryCard.isVatPaid) {
         <a class="govuk-link" href=@{
@@ -78,27 +79,27 @@
 }
 
 @cannotAppealDetails = {
-    @details(messages("summaryCard.details.summary"), cannotAppealContents)
+    @details(messages("summaryCard.details.summary"), cannotAppealContents, detailsClasses = Some("govuk-!-margin-bottom-0"))
 }
 
 
 @footerDisplayLogic = {
-@if(summaryCard.appealStatus.isEmpty || summaryCard.appealStatus.contains(AppealStatusEnum.Unappealable)) {
-    <div class="app-summary-card__actions">
-        <ul class="app-summary-card__actions-list">
-            <li class="app-summary-card__actions-list-item">
+    @if(summaryCard.appealStatus.isEmpty || summaryCard.appealStatus.contains(AppealStatusEnum.Unappealable)) {
+        <div class="app-summary-card__actions">
+            <ul class="app-summary-card__actions-list">
+                <li class="app-summary-card__actions-list-item">
+                @calculationContent
+                </li>
+                <li class="app-summary-card__actions-list-item">
+                @appealContent
+                </li>
+            </ul>
+        </div>
+    } else if(!summaryCard.appealStatus.contains(AppealStatusEnum.Upheld)) {
+        <div class="app-summary-card__link">
             @calculationContent
-            </li>
-            <li class="app-summary-card__actions-list-item">
-            @appealContent
-            </li>
-        </ul>
-    </div>
-} else {
-    <div class="app-summary-card__link">
-    @calculationContent
-    </div>
-}
+        </div>
+    }
 }
 
 
@@ -113,13 +114,13 @@
         @govukTag(summaryCard.status)
         </div>
     </header>
-    <div class="app-summary-card__body govuk-!-padding-bottom-0">
+    <div class="app-summary-card__body">
     @govukSummaryList(SummaryList(summaryCard.cardRows))
-    @if(!summaryCard.isVatPaid) {
+    @if(!summaryCard.isVatPaid && summaryCard.appealStatus.getOrElse(AppealStatusEnum.Unappealable) == AppealStatusEnum.Unappealable) {
         @cannotAppealDetails
     }
     </div>
     <footer class="app-summary-card__footer">
-    @footerDisplayLogic
+        @footerDisplayLogic
     </footer>
 </section>

--- a/test/views/components/LatePaymentPenaltySummaryCardSpec.scala
+++ b/test/views/components/LatePaymentPenaltySummaryCardSpec.scala
@@ -140,7 +140,8 @@ class LatePaymentPenaltySummaryCardSpec extends SpecBase with ViewBehaviours {
     Some(Seq(sampleLPP1.copy(penaltyCategory = LPPPenaltyCategoryEnum.LPP2,
       penaltyAmountPaid = Some(0.00),
       penaltyAmountOutstanding = Some(23.45),
-      penaltyStatus = LPPPenaltyStatusEnum.Posted)))
+      penaltyStatus = LPPPenaltyStatusEnum.Posted,
+      appealInformation = Some(Seq(AppealInformationType(Some(AppealStatusEnum.Under_Appeal), Some(AppealLevelEnum.HMRC)))))))
   ).get.head
 
   val summaryCardModelForAdditionalPenaltyDuePartiallyPaid: LatePaymentPenaltySummaryCard = summaryCardHelper.populateLatePaymentPenaltyCard(
@@ -339,6 +340,13 @@ class LatePaymentPenaltySummaryCardSpec extends SpecBase with ViewBehaviours {
         doc.select("dt").eq(5).isEmpty shouldBe true
       }
 
+      "not display the 'why you cannot appeal yet' drop down if the penalty has unappealable or no appeal status" in {
+        val doc: Document = asDocument(summaryCardHtml.apply(summaryCardModelForAdditionalPenaltyDue))
+        doc.select(".govuk-details__summary-text").isEmpty shouldBe true
+        doc.select(".govuk-details__text p:nth-child(1)").isEmpty shouldBe true
+        doc.select(".govuk-details__text p:nth-child(2)").isEmpty shouldBe true
+      }
+
       "display the 'why you cannot appeal yet' drop down if the penalty is unappealable (VAT has not been paid) and the user is an Agent" in {
         val doc: Document = asDocument(summaryCardHtml.apply(summaryCardModelForUnappealableLPP2)(messages, agentUser))
         doc.select(".govuk-details__summary-text").get(0).ownText() shouldBe "Why you cannot appeal yet"
@@ -347,7 +355,8 @@ class LatePaymentPenaltySummaryCardSpec extends SpecBase with ViewBehaviours {
         doc.select("dt").eq(5).isEmpty shouldBe true
       }
 
-      "display the 'why you cannot appeal yet' drop down with Central Assessment content if the VAT has not been paid and the Main Transaction is Central Assessment" in {
+      "display the 'why you cannot appeal yet' drop down with Central Assessment content if the VAT has not been paid and " +
+        "the Main Transaction is Central Assessment" in {
         val doc: Document = asDocument(summaryCardHtml.apply(summaryCardModelDueNoPaymentsMadeLPP2CentralAssessment))
         doc.select(".govuk-details__summary-text").get(0).ownText() shouldBe "Why you cannot appeal yet"
         doc.select(".govuk-details__text p:nth-child(1)").get(0).text() shouldBe "You cannot appeal until you submit the VAT Return and pay your VAT."
@@ -355,7 +364,8 @@ class LatePaymentPenaltySummaryCardSpec extends SpecBase with ViewBehaviours {
         doc.select("dt").eq(5).isEmpty shouldBe true
       }
 
-      "display the 'why you cannot appeal yet' drop down with Central Assessment content if the VAT has not been paid and the Main Transaction is Central Assessment and the user is an Agent" in {
+      "display the 'why you cannot appeal yet' drop down with Central Assessment content if the VAT has not been paid and the " +
+        "Main Transaction is Central Assessment and the user is an Agent" in {
         val doc: Document = asDocument(summaryCardHtml.apply(summaryCardModelDueNoPaymentsMadeLPP2CentralAssessment)(messages, agentUser))
         doc.select(".govuk-details__summary-text").get(0).ownText() shouldBe "Why you cannot appeal yet"
         doc.select(".govuk-details__text p:nth-child(1)").get(0).text() shouldBe "You cannot appeal until the VAT Return is submitted and your client pays the VAT."
@@ -372,19 +382,22 @@ class LatePaymentPenaltySummaryCardSpec extends SpecBase with ViewBehaviours {
       val docWithAppealedPenalty: Document =
         asDocument(summaryCardHtml.apply(summaryCardModelWithAppealedPenalty))
 
-      "have the appeal status for ACCEPTED" in {
+      "have the appeal status for ACCEPTED and not have the calculation link" in {
         docWithAppealedPenaltyAccepted.select("dt").get(4).text() shouldBe "Appeal status"
         docWithAppealedPenaltyAccepted.select("dd").get(4).text() shouldBe "Appeal accepted"
+        docWithAppealedPenaltyAccepted.select(".calculation-link").isEmpty shouldBe true
       }
 
       "have the appeal status for REJECTED" in {
         docWithAppealedPenaltyRejected.select("dt").get(4).text() shouldBe "Appeal status"
         docWithAppealedPenaltyRejected.select("dd").get(4).text() shouldBe "Appeal rejected"
+        docWithAppealedPenaltyRejected.select(".calculation-link").isEmpty shouldBe false
       }
 
       "have the appeal status for UNDER_REVIEW" in {
         docWithAppealedPenalty.select("dt").get(4).text() shouldBe "Appeal status"
         docWithAppealedPenalty.select("dd").get(4).text() shouldBe "Under review by HMRC"
+        docWithAppealedPenalty.select(".calculation-link").isEmpty shouldBe false
       }
     }
   }

--- a/test/views/components/LatePaymentPenaltySummaryCardSpec.scala
+++ b/test/views/components/LatePaymentPenaltySummaryCardSpec.scala
@@ -340,7 +340,7 @@ class LatePaymentPenaltySummaryCardSpec extends SpecBase with ViewBehaviours {
         doc.select("dt").eq(5).isEmpty shouldBe true
       }
 
-      "not display the 'why you cannot appeal yet' drop down if the penalty has unappealable or no appeal status" in {
+      "not display the 'why you cannot appeal yet' drop down if the penalty has an appeal status other than unappealable (e.g. under review)" in {
         val doc: Document = asDocument(summaryCardHtml.apply(summaryCardModelForAdditionalPenaltyDue))
         doc.select(".govuk-details__summary-text").isEmpty shouldBe true
         doc.select(".govuk-details__text p:nth-child(1)").isEmpty shouldBe true


### PR DESCRIPTION
£0 penalty is to be fixed in PRM-2538
![image](https://github.com/hmrc/penalties-frontend/assets/53828896/9ae505e8-9349-4844-925f-d2f28d00d9aa)
