### PR TITLE
[PRM-2589] - Added UR banner on penalties home page

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -37,6 +37,7 @@ class AppConfig @Inject()(val config: Configuration, servicesConfig: ServicesCon
   lazy val btaUrl: String = config.get[String]("urls.btaHomepage")
   lazy val penaltiesUrl: String = s"${servicesConfig.baseUrl("penalties")}/penalties"
   lazy val whatYouOweUrl: String = config.get[String]("urls.whatYouOwe")
+  lazy val userResearchBannerUrl: String = config.get[String]("urls.userResearchBannerUrl")
 
   lazy val signInUrl: String = config.get[String]("signIn.url")
 

--- a/app/views/IndexView.scala.html
+++ b/app/views/IndexView.scala.html
@@ -45,7 +45,8 @@
   isUserAgent = user.isAgent,
   isPageFullWidth = false,
   isCustomLayout = true,
-  optPage = Some(IndexPage)) {
+  optPage = Some(IndexPage),
+  showURBannerIfEnabled = true) {
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">@{

--- a/app/views/components/Header.scala.html
+++ b/app/views/components/Header.scala.html
@@ -14,19 +14,24 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.hmrcfrontend.views.html.components.{Header => compHeader, HmrcHeader}
+@import uk.gov.hmrc.hmrcfrontend.views.html.components.{Header => headerComponent, HmrcHeader}
 @import utils.SessionKeys
 @import config.AppConfig
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.{Cy, En}
+@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.userresearchbanner.UserResearchBanner
+@import uk.gov.hmrc.hmrcfrontend.views.config.StandardBetaBanner
+@import config.featureSwitches.ShowURBanner
 
-@this(hmrcHeader: HmrcHeader)
+@this(hmrcHeader: HmrcHeader, betaBanner: StandardBetaBanner)
 
-@(appConfig: AppConfig, showSignOut: Boolean = true)(implicit messages: Messages, request: Request[_])
+@(appConfig: AppConfig, showSignOut: Boolean = true, showURBannerIfEnabled: Boolean)(implicit messages: Messages, request: Request[_])
 
-@hmrcHeader(compHeader(
+@hmrcHeader(headerComponent(
     homepageUrl = "https://www.gov.uk/",
     serviceUrl = if(request.session.get(SessionKeys.agentSessionVrn).isDefined) {appConfig.vatOverviewUrlAgent} else {appConfig.vatOverviewUrl},
     serviceName = Some(if(request.session.get(SessionKeys.agentSessionVrn).isDefined) { messages("agent.service.name")} else { messages("service.name") }),
+    phaseBanner = Some(betaBanner(url = appConfig.feedbackUrl(request.uri))),
+    userResearchBanner = if(showURBannerIfEnabled && appConfig.isFeatureSwitchEnabled(ShowURBanner)) Some(UserResearchBanner(url = appConfig.userResearchBannerUrl)) else None,
     containerClasses = "govuk-width-container",
     navigation = None,
     signOutHref = if(showSignOut) Some(controllers.routes.SignOutController.signOut.url) else None,

--- a/app/views/components/UserResearchBanner.scala.html
+++ b/app/views/components/UserResearchBanner.scala.html
@@ -1,0 +1,23 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.hmrcfrontend.views.html.components.{HmrcUserResearchBanner, UserResearchBanner}
+
+@this(hmrcUserResearchBanner: HmrcUserResearchBanner)
+
+@(bannerUrl: String)
+
+@hmrcUserResearchBanner(UserResearchBanner(url = bannerUrl))

--- a/app/views/layouts/Layout.scala.html
+++ b/app/views/layouts/Layout.scala.html
@@ -38,11 +38,11 @@
         isTimeout: Boolean = false,
         isError: Boolean = false,
         isCustomLayout: Boolean = false,
-        optPage: Option[Page] = None
+        optPage: Option[Page] = None,
+        showURBannerIfEnabled: Boolean = false
 )(contentBlock: Html)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
 @beforeContentBlock = {
-@phaseBanner("beta")
 @if(appConfig.welshLanguageSupportEnabled) {@languageSelect()}
 
 @if(!isTimeout && !isError){
@@ -115,10 +115,11 @@
 @titleMessage = @{
   if(isUserAgent) "agent.service.name" else "service.name"
 }
+
 @govukLayout(
     pageTitle = Some(messages("common.pageTitle", pageTitle, messages(titleMessage))),
     headBlock = Some(headBlock),
-    headerBlock = Some(header(appConfig, !isTimeout)),
+    headerBlock = Some(header(appConfig, !isTimeout, showURBannerIfEnabled)),
     scriptsBlock = Some(scripts),
     beforeContentBlock = Some(beforeContentBlock),
     footerBlock = Some(hmrcStandardFooter()),

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -96,6 +96,7 @@ urls {
   adjustmentUrl = "https://www.gov.uk/guidance/penalty-points-and-penalties-if-you-submit-your-vat-return-late#how-changes-to-your-business-affect-penalty-points"
   lspGuidanceUrl = "https://www.gov.uk/guidance/penalty-points-and-penalties-if-you-submit-your-vat-return-late"
   lppCalculationGuidance = "https://www.gov.uk/guidance/how-late-payment-penalties-work-if-you-pay-vat-late"
+  userResearchBannerUrl = "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=VAT_penalty&utm_source=Other&utm_medium=other&t=HMRC&id=535"
 }
 
 metrics {

--- a/test/assets/messages/IndexMessages.scala
+++ b/test/assets/messages/IndexMessages.scala
@@ -115,7 +115,13 @@ object IndexMessages {
   val appealStatus = "Appeal status"
   def lspMultiplePenaltyPeriodMessage(dueDate : String) = s"The VAT Return due on $dueDate was also submitted late. <br> HMRC only applies 1 penalty for late submission in each month."
 
-  val betaFeedbackContent = "This is a new service - your feedback will help us to improve it."
+  val betaFeedbackContent = "This is a new service – your feedback will help us to improve it."
+
+  val urBannerHeader = "Help make GOV.UK better"
+
+  val urBannerLinkText = "Sign up to take part in research (opens in new tab)"
+
+  val urBannerHideMessageButtonText = "Hide message"
 
   val whatYouOweButtonText = "Check amounts and pay"
   val whatYouOweButtonAgentText = "Check amounts"

--- a/test/views/CalculationViewSpec.scala
+++ b/test/views/CalculationViewSpec.scala
@@ -53,7 +53,7 @@ class CalculationViewSpec extends SpecBase with ViewBehaviours with ViewUtils {
 
     val calculation = "#calculation"
 
-    val betaFeedbackBannerText =  "body > div > div.govuk-phase-banner > p > span"
+    val betaFeedbackBannerText =  ".govuk-phase-banner__text"
 
     val ttpInsetText = "#ttp-inset-text"
 
@@ -1047,7 +1047,7 @@ class CalculationViewSpec extends SpecBase with ViewBehaviours with ViewUtils {
     }
   }
 
-  "have a beta banner with the feedback correct content and a link with the 'backURL' queryParam" in {
+  "have a beta banner with the feedback link and correct content and a link with the 'backUrl' queryParam" in {
     def applyView(): HtmlFormat.Appendable = calculationLPP2Page.apply(
       isEstimate = true,
       startDate = "1 April 2022",
@@ -1061,7 +1061,7 @@ class CalculationViewSpec extends SpecBase with ViewBehaviours with ViewUtils {
     )(implicitly, implicitly, vatTraderUser)
     val doc: Document = asDocument(applyView())
 
-    doc.select(Selector.betaFeedbackBannerText).text() shouldBe "This is a new service - your feedback will help us to improve it."
-    doc.select("#beta-feedback-link").attr("href").contains("http://localhost:9250/contact/beta-feedback?service=vat-penalties&backUrl=") shouldBe true
+    doc.select(Selector.betaFeedbackBannerText).text() shouldBe "This is a new service – your feedback will help us to improve it."
+    doc.select(".govuk-phase-banner__text > .govuk-link").attr("href").contains("http://localhost:9250/contact/beta-feedback?service=vat-penalties&backUrl=") shouldBe true
   }
 }

--- a/test/views/ComplianceViewSpec.scala
+++ b/test/views/ComplianceViewSpec.scala
@@ -63,7 +63,7 @@ class ComplianceViewSpec extends SpecBase with ViewBehaviours with ViewUtils {
 
     val returnToVATLink = "#main-content > div > div > p > a"
 
-    val betaFeedbackBannerText = "body > div > div.govuk-phase-banner > p > span"
+    val betaFeedbackBannerText =  ".govuk-phase-banner__text"
   }
 
   "ComplianceView" should {
@@ -139,12 +139,12 @@ class ComplianceViewSpec extends SpecBase with ViewBehaviours with ViewUtils {
       }
     }
 
-    "have a beta banner with the feedback correct content and a link with the 'backURL' queryParam" in {
+    "have a beta banner with the feedback link and correct content and a link with the 'backUrl' queryParam" in {
       def applyView(): HtmlFormat.Appendable = compliancePage.apply(html(), "", "")(implicitly, implicitly, vatTraderUser)
       val doc: Document = asDocument(applyView())
 
-      doc.select(Selectors.betaFeedbackBannerText).text() shouldBe "This is a new service - your feedback will help us to improve it."
-      doc.select("#beta-feedback-link").attr("href").contains("http://localhost:9250/contact/beta-feedback?service=vat-penalties&backUrl=") shouldBe true
+      doc.select(Selectors.betaFeedbackBannerText).text() shouldBe "This is a new service – your feedback will help us to improve it."
+      doc.select(".govuk-phase-banner__text > .govuk-link").attr("href").contains("http://localhost:9250/contact/beta-feedback?service=vat-penalties&backUrl=") shouldBe true
     }
 
   }

--- a/test/views/IndexViewSpec.scala
+++ b/test/views/IndexViewSpec.scala
@@ -32,7 +32,13 @@ class IndexViewSpec extends SpecBase with ViewUtils with ViewBehaviours with Tes
 
 
   object Selectors extends BaseSelectors {
-    val betaFeedbackBannerText =  "body > div > div.govuk-phase-banner > p > span"
+    val betaFeedbackBannerText =  ".govuk-phase-banner__text"
+
+    val urBannerHeader = ".hmrc-user-research-banner__title"
+
+    val urBannerLink = ".hmrc-user-research-banner__link"
+
+    val hideURBannerButton = ".hmrc-user-research-banner__close > span"
 
     val timeToPayParagraph: Int => String = (index: Int) => s"#time-to-pay > p:nth-child($index)"
 
@@ -86,9 +92,16 @@ class IndexViewSpec extends SpecBase with ViewUtils with ViewBehaviours with Tes
 
       behave like pageWithExpectedMessages(expectedContent)
 
-      "have a beta banner with the feedback correct content and a link with the 'backUrl' queryParam" in {
+      "have a UR banner with the correct content" in {
+        doc.select(Selectors.urBannerHeader).text() shouldBe urBannerHeader
+        doc.select(Selectors.urBannerLink).text() shouldBe urBannerLinkText
+        doc.select(Selectors.urBannerLink).attr("href") shouldBe "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=VAT_penalty&utm_source=Other&utm_medium=other&t=HMRC&id=535"
+        doc.select(Selectors.hideURBannerButton).get(0).text() shouldBe urBannerHideMessageButtonText
+      }
+
+      "have a beta banner with the feedback link and correct content and a link with the 'backUrl' queryParam" in {
         doc.select(Selectors.betaFeedbackBannerText).text() shouldBe betaFeedbackContent
-        doc.select("#beta-feedback-link").attr("href").contains("http://localhost:9250/contact/beta-feedback?service=vat-penalties&backUrl=") shouldBe true
+        doc.select(".govuk-phase-banner__text > .govuk-link").attr("href").contains("http://localhost:9250/contact/beta-feedback?service=vat-penalties&backUrl=") shouldBe true
       }
     }
 

--- a/test/views/components/HeaderSpec.scala
+++ b/test/views/components/HeaderSpec.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components
+
+import base.SpecBase
+import config.AppConfig
+import config.featureSwitches.ShowURBanner
+import org.mockito.Matchers
+import org.mockito.Matchers.any
+import org.mockito.Mockito.{mock, when}
+import views.behaviours.ViewBehaviours
+import views.html.components.Header
+
+class HeaderSpec extends SpecBase with ViewBehaviours {
+  val mockAppConfig: AppConfig = mock(classOf[AppConfig])
+  val headerHtml: Header = injector.instanceOf[Header]
+
+  when(mockAppConfig.feedbackUrl(any())).thenReturn("http://example.com")
+
+  "Header" should {
+    "display the UR banner" when {
+      "the show UR banner feature is enabled and the 'showURBannerIfEnabled' parameter is true" in {
+        when(mockAppConfig.isFeatureSwitchEnabled(Matchers.eq(ShowURBanner))).thenReturn(true)
+        when(mockAppConfig.userResearchBannerUrl).thenReturn("http://user-research.com")
+        val html = headerHtml.apply(mockAppConfig, showURBannerIfEnabled = true)
+        val htmlDocument = asDocument(html)
+        htmlDocument.select(".hmrc-user-research-banner__title").text() shouldBe "Help make GOV.UK better"
+        htmlDocument.select(".hmrc-user-research-banner__link").text() shouldBe "Sign up to take part in research (opens in new tab)"
+      }
+    }
+
+    "not display the UR banner" when {
+      "the show UR banner feature is disabled" in {
+        when(mockAppConfig.isFeatureSwitchEnabled(Matchers.eq(ShowURBanner))).thenReturn(false)
+        val html = headerHtml.apply(mockAppConfig, showURBannerIfEnabled = true)
+        val htmlDocument = asDocument(html)
+        htmlDocument.select(".hmrc-user-research-banner__title").isEmpty shouldBe true
+        htmlDocument.select(".hmrc-user-research-banner__link").isEmpty shouldBe true
+      }
+
+      "the 'showURBannerIfEnabled' parameter is false" in {
+        when(mockAppConfig.isFeatureSwitchEnabled(Matchers.eq(ShowURBanner))).thenReturn(true)
+        val html = headerHtml.apply(mockAppConfig, showURBannerIfEnabled = false)
+        val htmlDocument = asDocument(html)
+        htmlDocument.select(".hmrc-user-research-banner__title").isEmpty shouldBe true
+        htmlDocument.select(".hmrc-user-research-banner__link").isEmpty shouldBe true
+      }
+
+      "both feature and parameter return false" in {
+        when(mockAppConfig.isFeatureSwitchEnabled(Matchers.eq(ShowURBanner))).thenReturn(false)
+        val html = headerHtml.apply(mockAppConfig, showURBannerIfEnabled = false)
+        val htmlDocument = asDocument(html)
+        htmlDocument.select(".hmrc-user-research-banner__title").isEmpty shouldBe true
+        htmlDocument.select(".hmrc-user-research-banner__link").isEmpty shouldBe true
+
+      }
+    }
+  }
+}


### PR DESCRIPTION
UR banner should be below the phase banner but this is a library that will be fixed by another team:
![image](https://github.com/hmrc/penalties-frontend/assets/53828896/03604b31-e21a-4693-a532-61495d7bbcda)
