### PR TITLE
[PRM-3129] - Added feature switch and content for obligation link change

### DIFF
--- a/app/config/featureSwitches/FeatureSwitch.scala
+++ b/app/config/featureSwitches/FeatureSwitch.scala
@@ -22,11 +22,16 @@ sealed trait FeatureSwitch {
 
 object FeatureSwitch {
   val prefix: String = "feature.switch"
-  val listOfAllFeatureSwitches: List[FeatureSwitch] = List(ShowURBanner)
+  val listOfAllFeatureSwitches: List[FeatureSwitch] = List(ShowURBanner, ShowAppealAgainstObligationChanges)
 }
 
 case object ShowURBanner extends FeatureSwitch {
   override val name: String = s"${FeatureSwitch.prefix}.show-ur-banner"
+}
+
+//TODO: remove once the new appeal obligation changes are ready
+case object ShowAppealAgainstObligationChanges extends FeatureSwitch {
+  override val name: String = s"${FeatureSwitch.prefix}.show-appeal-against-obligation-changes"
 }
 
 

--- a/app/viewmodels/LateSubmissionPenaltySummaryCard.scala
+++ b/app/viewmodels/LateSubmissionPenaltySummaryCard.scala
@@ -37,5 +37,6 @@ case class LateSubmissionPenaltySummaryCard(
                                              isAddedOrRemovedPoint: Boolean = false,
                                              isManuallyRemovedPoint: Boolean = false,
                                              multiplePenaltyPeriod: Option[Html] = None,
-                                             dueDate: Option[String]
+                                             dueDate: Option[String],
+                                             showFindOutHowToAppealText: Boolean
                                            )

--- a/app/viewmodels/SummaryCardHelper.scala
+++ b/app/viewmodels/SummaryCardHelper.scala
@@ -16,8 +16,10 @@
 
 package viewmodels
 
-import java.time.LocalDate
+import config.AppConfig
+import config.featureSwitches.{FeatureSwitching, ShowAppealAgainstObligationChanges}
 
+import java.time.LocalDate
 import javax.inject.Inject
 import models.User
 import models.appealInfo.AppealStatusEnum
@@ -32,7 +34,7 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Key, SummaryListR
 import uk.gov.hmrc.govukfrontend.views.viewmodels.tag.Tag
 import utils.{CurrencyFormatter, ImplicitDateFormatter, PenaltyPeriodHelper, ViewUtils}
 
-class SummaryCardHelper @Inject()() extends ImplicitDateFormatter with ViewUtils {
+class SummaryCardHelper @Inject()(val appConfig: AppConfig) extends ImplicitDateFormatter with ViewUtils with FeatureSwitching {
 
   def populateLateSubmissionPenaltyCard(penalties: Seq[LSPDetails],
                                         threshold: Int, activePoints: Int)
@@ -97,7 +99,8 @@ class SummaryCardHelper @Inject()() extends ImplicitDateFormatter with ViewUtils
       isManuallyRemovedPoint = isManuallyRemovedPoint,
       multiplePenaltyPeriod = getMultiplePenaltyPeriodMessage(penalty),
       dueDate = dueDate.map(dateToString(_)),
-      penaltyCategory = penalty.penaltyCategory
+      penaltyCategory = penalty.penaltyCategory,
+      showFindOutHowToAppealText = isEnabled(ShowAppealAgainstObligationChanges)
     )
   }
 
@@ -173,7 +176,8 @@ class SummaryCardHelper @Inject()() extends ImplicitDateFormatter with ViewUtils
       appealLevel = appealLevel,
       totalPenaltyAmount = penalty.chargeAmount.getOrElse(BigDecimal(0)),
       multiplePenaltyPeriod = getMultiplePenaltyPeriodMessage(penalty),
-      dueDate = dueDate.map(dateToString(_))
+      dueDate = dueDate.map(dateToString(_)),
+      showFindOutHowToAppealText = isEnabled(ShowAppealAgainstObligationChanges)
     )
   }
 

--- a/app/views/components/summaryCardLSP.scala.html
+++ b/app/views/components/summaryCardLSP.scala.html
@@ -19,6 +19,7 @@
 @import utils.CurrencyFormatter
 @import viewmodels.LateSubmissionPenaltySummaryCard
 @import models.lsp.LSPPenaltyCategoryEnum
+@import config.featureSwitches.ShowAppealAgainstObligationChanges
 
 @this(
         govukSummaryList: GovukSummaryList,
@@ -98,7 +99,11 @@
                     } else if(summaryCard.penaltyCategory.contains(LSPPenaltyCategoryEnum.Charge) && !summaryCard.isAddedOrRemovedPoint) {
                             {if(!summaryCard.isReturnSubmitted || summaryCard.appealStatus.contains(AppealStatusEnum.Unappealable)) {
                                     <a class="govuk-link" href={controllers.routes.IndexController.redirectToAppeals(summaryCard.penaltyId, false, true, false).url}>
-                                    {messages("summaryCard.appealCheck")} <span class="govuk-visually-hidden">{visuallyHiddenText.getOrElse("")}</span>
+                                    {if(summaryCard.showFindOutHowToAppealText) {
+                                      messages("summaryCard.findOutHowToAppeal")
+                                    } else {
+                                      messages("summaryCard.appealCheck")
+                                    }}<span class="govuk-visually-hidden">{visuallyHiddenText.getOrElse("")}</span>
                                     </a>
                             } else {
                                     <a class="govuk-link" href={controllers.routes.IndexController.redirectToAppeals(summaryCard.penaltyId, false, false, false).url}>
@@ -108,7 +113,11 @@
                     } else if(!summaryCard.isAddedOrRemovedPoint) {
                         if(!summaryCard.isReturnSubmitted || summaryCard.appealStatus.contains(AppealStatusEnum.Unappealable)) {
                                 <a class="govuk-link" href={controllers.routes.IndexController.redirectToAppeals(summaryCard.penaltyId, false, true, false).url}>
-                                {messages("summaryCard.appealCheck")} <span class="govuk-visually-hidden">{visuallyHiddenText.getOrElse("")}</span>
+                                {if(summaryCard.showFindOutHowToAppealText) {
+                                  messages("summaryCard.findOutHowToAppeal")
+                                } else {
+                                  messages("summaryCard.appealCheck")
+                                }} <span class="govuk-visually-hidden">{visuallyHiddenText.getOrElse("")}</span>
                                 </a>
                         } else {
                                 <a class="govuk-link" href={controllers.routes.IndexController.redirectToAppeals(summaryCard.penaltyId, false, false, false).url}>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -69,6 +69,7 @@ feature {
   switch {
     time-machine-now = ""
     show-ur-banner = true
+    show-appeal-against-obligation-changes = false
   }
 }
 

--- a/conf/messages
+++ b/conf/messages
@@ -112,6 +112,7 @@ summaryCard.removalReason.FAP = Change to VAT return deadlines
 summaryCard.removalReason.MAN = Removed by HMRC
 summaryCard.infoOnAdjustmentPointsLinkText = Read the guidance about adjustment points
 summaryCard.appealCheck = Check if you can appeal
+summaryCard.findOutHowToAppeal = Find out how to appeal
 summaryCard.lpp.key2 = Penalty type
 summaryCard.lpp.key2.value.lpp1 = First penalty for late payment
 summaryCard.lpp.key2.value.lpp2 = Second penalty for late payment

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -112,6 +112,7 @@ summaryCard.removalReason.FAP = Newid i ddyddiadau cau ar gyfer Ffurflenni TAW
 summaryCard.removalReason.MAN = Wedi’i ddileu gan CThEF
 summaryCard.infoOnAdjustmentPointsLinkText = Darllenwch yr arweiniad ynghylch pwyntiau addasu
 summaryCard.appealCheck = Gwirio a allwch apelio
+summaryCard.findOutHowToAppeal = Dysgwch sut i apelio
 summaryCard.lpp.key2 = Math o gosb
 summaryCard.lpp.key2.value.lpp1 = Cosb gyntaf am dalu’n hwyr
 summaryCard.lpp.key2.value.lpp2 = Ail gosb am dalu’n hwyr

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,5 +1,3 @@
 # Add all the application routes to the app.routes file
 ->         /penalties                 app.Routes
 ->         /                          health.Routes
-
-GET        /admin/metrics             com.kenshoo.play.metrics.MetricsController.metrics

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object AppDependencies {
 
-  lazy val bootstrapVersion = "7.23.0"
+  lazy val bootstrapVersion = "8.1.0"
 
   val compile = Seq(
     "uk.gov.hmrc"                  %% "bootstrap-frontend-play-28" % bootstrapVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"         % "3.15.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"     % "2.2.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin"             % "2.8.20")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"             % "2.8.21")
 addSbtPlugin("org.irundaia.sbt"  % "sbt-sassify"            % "1.5.1")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"          % "1.9.3")
 addSbtPlugin("org.scalastyle"    %% "scalastyle-sbt-plugin" % "1.0.0")

--- a/test/config/featureSwitches/FeatureSwitchSpec.scala
+++ b/test/config/featureSwitches/FeatureSwitchSpec.scala
@@ -31,7 +31,7 @@ class FeatureSwitchSpec extends SpecBase {
 
   "listOfAllFeatureSwitches" should {
     "be all the featureswitches in the app" in {
-      FeatureSwitch.listOfAllFeatureSwitches shouldBe List(ShowURBanner)
+      FeatureSwitch.listOfAllFeatureSwitches shouldBe List(ShowURBanner, ShowAppealAgainstObligationChanges)
     }
   }
 }

--- a/test/viewmodels/SummaryCardHelperSpec.scala
+++ b/test/viewmodels/SummaryCardHelperSpec.scala
@@ -51,7 +51,8 @@ class SummaryCardHelperSpec extends SpecBase with ImplicitDateFormatter {
     "12345678901234",
     isReturnSubmitted = true,
     dueDate = Some(dateToString(taxPeriodDue)),
-    penaltyCategory = Some(LSPPenaltyCategoryEnum.Point)
+    penaltyCategory = Some(LSPPenaltyCategoryEnum.Point),
+    showFindOutHowToAppealText = false
   )
 
   def sampleLPPSummaryCardPenaltyPaid(chargeType: String, isAgent: Boolean = false, isCentralAssessment: Boolean = false): LatePaymentPenaltySummaryCard = {
@@ -215,7 +216,8 @@ class SummaryCardHelperSpec extends SpecBase with ImplicitDateFormatter {
           penaltyCategory = Some(LSPPenaltyCategoryEnum.Charge),
           totalPenaltyAmount = 200,
           multiplePenaltyPeriod = None,
-          dueDate = Some(dateToString(taxPeriodDue))
+          dueDate = Some(dateToString(taxPeriodDue)),
+          showFindOutHowToAppealText = false
         )
 
         val pointToPassIn: LSPDetails = sampleLateSubmissionPenaltyCharge.copy(penaltyOrder = Some("05"))
@@ -239,7 +241,8 @@ class SummaryCardHelperSpec extends SpecBase with ImplicitDateFormatter {
           isReturnSubmitted = true,
           penaltyCategory = Some(LSPPenaltyCategoryEnum.Threshold),
           totalPenaltyAmount = 200,
-          dueDate = Some(dateToString(taxPeriodDue))
+          dueDate = Some(dateToString(taxPeriodDue)),
+          showFindOutHowToAppealText = false
         )
 
         val pointToPassIn: LSPDetails = sampleLateSubmissionPenaltyCharge.copy(penaltyOrder = Some("01"), penaltyCategory = Some(LSPPenaltyCategoryEnum.Threshold))
@@ -343,7 +346,8 @@ class SummaryCardHelperSpec extends SpecBase with ImplicitDateFormatter {
           penaltyCategory = Some(LSPPenaltyCategoryEnum.Charge),
           totalPenaltyAmount = 200,
           multiplePenaltyPeriod = Some(Html(lspMultiplePenaltyPeriodMessage(dateToString(taxPeriodDue.plusMonths(1))))),
-          dueDate = Some(dateToString(taxPeriodDue))
+          dueDate = Some(dateToString(taxPeriodDue)),
+          showFindOutHowToAppealText = false
         )
 
         val actualResult = helper.financialSummaryCard(sampleLateSubmissionPenaltyChargeWithMultiplePeriods, monthlyThreshold)
@@ -366,7 +370,8 @@ class SummaryCardHelperSpec extends SpecBase with ImplicitDateFormatter {
           isReturnSubmitted = false,
           penaltyCategory = Some(LSPPenaltyCategoryEnum.Threshold),
           totalPenaltyAmount = 200,
-          dueDate = Some(dateToString(taxPeriodDue))
+          dueDate = Some(dateToString(taxPeriodDue)),
+          showFindOutHowToAppealText = false
         )
 
         val pointToPassIn: LSPDetails = sampleLateSubmissionPenaltyCharge.copy(penaltyOrder = Some("01"), penaltyCategory = Some(LSPPenaltyCategoryEnum.Threshold),
@@ -417,6 +422,7 @@ class SummaryCardHelperSpec extends SpecBase with ImplicitDateFormatter {
             isReturnSubmitted = true,
             dueDate = Some(dateToString(taxPeriodDue)),
             penaltyCategory = Some(LSPPenaltyCategoryEnum.Point),
+            showFindOutHowToAppealText = false
           ),
             LateSubmissionPenaltySummaryCard(
               Seq(
@@ -434,6 +440,7 @@ class SummaryCardHelperSpec extends SpecBase with ImplicitDateFormatter {
               isReturnSubmitted = true,
               dueDate = Some(dateToString(taxPeriodDue.plusMonths(1))),
               penaltyCategory = Some(LSPPenaltyCategoryEnum.Point),
+              showFindOutHowToAppealText = false
             ),
             LateSubmissionPenaltySummaryCard(
               Seq(
@@ -450,7 +457,8 @@ class SummaryCardHelperSpec extends SpecBase with ImplicitDateFormatter {
               "12345678901234",
               isReturnSubmitted = true,
               dueDate = Some(dateToString(taxPeriodDue.plusMonths(2))),
-              penaltyCategory = Some(LSPPenaltyCategoryEnum.Point)
+              penaltyCategory = Some(LSPPenaltyCategoryEnum.Point),
+              showFindOutHowToAppealText = false
             ),
             LateSubmissionPenaltySummaryCard(
               Seq(
@@ -466,7 +474,8 @@ class SummaryCardHelperSpec extends SpecBase with ImplicitDateFormatter {
               isReturnSubmitted = true,
               isAddedOrRemovedPoint = true,
               dueDate = Some(dateToString(taxPeriodDue.minusMonths(1))),
-              penaltyCategory = Some(LSPPenaltyCategoryEnum.Point)
+              penaltyCategory = Some(LSPPenaltyCategoryEnum.Point),
+              showFindOutHowToAppealText = false
             ))
 
 
@@ -495,7 +504,8 @@ class SummaryCardHelperSpec extends SpecBase with ImplicitDateFormatter {
               "0987654321",
               isReturnSubmitted = true,
               dueDate = Some(dateToString(taxPeriodDue)),
-              penaltyCategory = None
+              penaltyCategory = None,
+              showFindOutHowToAppealText = false
             ))
           val result = helper.populateLateSubmissionPenaltyCard(Seq(sampleLateSubmissionPointReturnWithNoPenaltyCategory), quarterlyThreshold, quarterlyThreshold -1)
           result.head shouldBe expectedResult.head

--- a/test/views/components/LateSubmissionPenaltySummaryCardSpec.scala
+++ b/test/views/components/LateSubmissionPenaltySummaryCardSpec.scala
@@ -17,25 +17,35 @@
 package views.components
 
 import base.{BaseSelectors, SpecBase}
+import config.featureSwitches.{FeatureSwitching, ShowAppealAgainstObligationChanges}
 import models.User
 import models.appealInfo.{AppealInformationType, AppealLevelEnum, AppealStatusEnum}
 import models.lsp._
 import org.jsoup.nodes.Document
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import viewmodels.LateSubmissionPenaltySummaryCard
 import views.behaviours.ViewBehaviours
 import views.html.components.summaryCardLSP
 
 import java.time.LocalDate
 
-class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours {
+class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours with FeatureSwitching with BeforeAndAfterAll with BeforeAndAfterEach {
 
   object Selectors extends BaseSelectors
 
   implicit val user: User[_] = vatTraderUser
 
+  class Setup(isShowAppealAgainstObligationChangesEnabled: Boolean = false) {
+    if(isShowAppealAgainstObligationChangesEnabled) {
+      enableFeatureSwitch(ShowAppealAgainstObligationChanges)
+    } else {
+      disableFeatureSwitch(ShowAppealAgainstObligationChanges)
+    }
+  }
+
   val summaryCardHtml: summaryCardLSP = injector.instanceOf[summaryCardLSP]
 
-  val summaryCardModelWithAppealedPoint: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
+  def summaryCardModelWithAppealedPoint: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
     Seq(sampleLateSubmissionPenaltyCharge.copy(
       appealInformation = Some(Seq(
         AppealInformationType(
@@ -45,7 +55,7 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
       )), lspTypeEnum = Some(LSPTypeEnum.Financial))),
     monthlyThreshold, 1).head
 
-  val summaryCardModelUnappealable: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
+  def summaryCardModelUnappealable: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
     Seq(sampleLateSubmissionPenaltyCharge.copy(
       appealInformation = Some(Seq(
         AppealInformationType(
@@ -55,7 +65,7 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
       )), lspTypeEnum = Some(LSPTypeEnum.Financial))),
     quarterlyThreshold, 1).head
 
-  val summaryCardModelWithAppealedPointAccepted: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
+  def summaryCardModelWithAppealedPointAccepted: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
     Seq(sampleLateSubmissionPenaltyCharge.copy(
       penaltyStatus = LSPPenaltyStatusEnum.Inactive,
       expiryReason = Some(ExpiryReasonEnum.Appeal),
@@ -69,7 +79,7 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
       )), lspTypeEnum = Some(LSPTypeEnum.AppealedPoint))),
     quarterlyThreshold, 0).head
 
-  val summaryCardModelWithAppealedPointRejected: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
+  def summaryCardModelWithAppealedPointRejected: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
     Seq(sampleLateSubmissionPenaltyCharge.copy(appealInformation = Some(Seq(
       AppealInformationType(
         appealStatus = Some(AppealStatusEnum.Rejected),
@@ -78,7 +88,7 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
     )), lspTypeEnum = Some(LSPTypeEnum.Financial))),
     quarterlyThreshold, 1).head
 
-  val summaryCardModelWithAddedPoint: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
+  def summaryCardModelWithAddedPoint: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
     Seq(LSPDetails(
       penaltyNumber = "12345678901234",
       penaltyOrder = Some("01"),
@@ -111,7 +121,7 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
     )
     ), quarterlyThreshold, 1).head
 
-  val summaryCardModelWithAppealedPointUnderTribunalReview: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
+  def summaryCardModelWithAppealedPointUnderTribunalReview: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
     Seq(sampleLateSubmissionPenaltyCharge.copy(
       appealInformation = Some(Seq(
         AppealInformationType(
@@ -122,7 +132,7 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
     )),
     quarterlyThreshold, 1).head
 
-  val summaryCardModelWithAppealedPointAcceptedByTribunal: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
+  def summaryCardModelWithAppealedPointAcceptedByTribunal: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
     Seq(sampleLateSubmissionPenaltyCharge.copy(
       penaltyStatus = LSPPenaltyStatusEnum.Inactive,
       expiryReason = Some(ExpiryReasonEnum.Appeal),
@@ -138,7 +148,7 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
     )),
     quarterlyThreshold, 0).head
 
-  val summaryCardModelWithAppealedPointTribunalRejected: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
+  def summaryCardModelWithAppealedPointTribunalRejected: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
     Seq(sampleLateSubmissionPenaltyCharge.copy(
       appealInformation = Some(Seq(
         AppealInformationType(
@@ -149,7 +159,7 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
     )),
     quarterlyThreshold, 1).head
 
-  val summaryCardModelWithAddedPointAtThreshold: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
+  def summaryCardModelWithAddedPointAtThreshold: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
     Seq(LSPDetails(
       penaltyNumber = "12345678901234",
       penaltyOrder = Some("01"),
@@ -177,7 +187,7 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
     )
     ), quarterlyThreshold, 4).head
 
-  val summaryCardModelWithRemovedPoint: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
+  def summaryCardModelWithRemovedPoint: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
     Seq(LSPDetails(
       penaltyNumber = "12345678901234",
       penaltyOrder = Some("01"),
@@ -205,7 +215,7 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
     )
     ), quarterlyThreshold, 1).head
 
-  val summaryCardModelWithRemovedPointFilingFrequencyChange: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
+  def summaryCardModelWithRemovedPointFilingFrequencyChange: LateSubmissionPenaltySummaryCard = summaryCardHelper.populateLateSubmissionPenaltyCard(
     Seq(LSPDetails(
       penaltyNumber = "12345678901234",
       penaltyOrder = Some("01"),
@@ -237,7 +247,7 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
       lspTypeEnum = Some(LSPTypeEnum.RemovedFAP)
     )), quarterlyThreshold, 1).head
 
-  val summaryCardModelWithThresholdPenalty: LateSubmissionPenaltySummaryCard = summaryCardHelper.financialSummaryCard(
+  def summaryCardModelWithThresholdPenalty: LateSubmissionPenaltySummaryCard = summaryCardHelper.financialSummaryCard(
     LSPDetails(
       penaltyNumber = "12345678901238",
       penaltyOrder = Some("01"),
@@ -269,7 +279,7 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
       lspTypeEnum = Some(LSPTypeEnum.Point)
     ), quarterlyThreshold)
 
-  val summaryCardModelNoReturnSubmitted: LateSubmissionPenaltySummaryCard = summaryCardHelper.financialSummaryCard(
+  def summaryCardModelNoReturnSubmitted: LateSubmissionPenaltySummaryCard = summaryCardHelper.financialSummaryCard(
     LSPDetails(
       penaltyNumber = "12345678901238",
       penaltyOrder = Some("01"),
@@ -296,7 +306,7 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
       lspTypeEnum = Some(LSPTypeEnum.Point)
     ), quarterlyThreshold)
 
-  val summaryCardModelWithFinancialPointBelowThresholdAndAppealInProgress: LateSubmissionPenaltySummaryCard =
+  def summaryCardModelWithFinancialPointBelowThresholdAndAppealInProgress: LateSubmissionPenaltySummaryCard =
     summaryCardHelper.financialSummaryCard(LSPDetails(
       penaltyNumber = "12345678901234",
       penaltyOrder = Some("01"),
@@ -328,7 +338,7 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
       lspTypeEnum = Some(LSPTypeEnum.AddedFAP)
     ), quarterlyThreshold)
 
-  val summaryCardModelForFinancialPenaltyWithAndAppealRejected: LateSubmissionPenaltySummaryCard =
+  def summaryCardModelForFinancialPenaltyWithAndAppealRejected: LateSubmissionPenaltySummaryCard =
     summaryCardHelper.financialSummaryCard(LSPDetails(
       penaltyNumber = "12345678901234",
       penaltyOrder = Some("01"),
@@ -360,7 +370,7 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
       lspTypeEnum = Some(LSPTypeEnum.Financial)
     ), quarterlyThreshold)
 
-  val summaryCardModelWithFinancialPointBelowThresholdAndAppealUnderTribunalReview: LateSubmissionPenaltySummaryCard =
+  def summaryCardModelWithFinancialPointBelowThresholdAndAppealUnderTribunalReview: LateSubmissionPenaltySummaryCard =
     summaryCardHelper.financialSummaryCard(LSPDetails(
       penaltyNumber = "12345678901234",
       penaltyOrder = Some("01"),
@@ -392,7 +402,7 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
       lspTypeEnum = Some(LSPTypeEnum.AddedFAP)
     ), quarterlyThreshold)
 
-  val summaryCardModelWithFinancialPointBelowThresholdAndAppealTribunalRejected: LateSubmissionPenaltySummaryCard =
+  def summaryCardModelWithFinancialPointBelowThresholdAndAppealTribunalRejected: LateSubmissionPenaltySummaryCard =
     summaryCardHelper.financialSummaryCard(LSPDetails(
       penaltyNumber = "12345678901234",
       penaltyOrder = Some("01"),
@@ -424,8 +434,7 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
       lspTypeEnum = Some(LSPTypeEnum.Point)
     ), quarterlyThreshold)(implicitly)
 
-
-  val summaryCardModelWithFinancialLSP: Boolean => LateSubmissionPenaltySummaryCard = (isSubmitted: Boolean) => summaryCardHelper.financialSummaryCard(LSPDetails(
+  def summaryCardModelWithFinancialLSP: Boolean => LateSubmissionPenaltySummaryCard = (isSubmitted: Boolean) => summaryCardHelper.financialSummaryCard(LSPDetails(
     penaltyNumber = "12345678901234",
     penaltyOrder = Some("01"),
     penaltyCategory = Some(LSPPenaltyCategoryEnum.Charge),
@@ -451,7 +460,7 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
     lspTypeEnum = Some(LSPTypeEnum.Financial)
   ), annualThreshold)(implicitly)
 
-  val summaryCardModelWithMultiplePenaltyPeriodLSP: LateSubmissionPenaltySummaryCard = summaryCardHelper.financialSummaryCard(LSPDetails(
+  def summaryCardModelWithMultiplePenaltyPeriodLSP: LateSubmissionPenaltySummaryCard = summaryCardHelper.financialSummaryCard(LSPDetails(
     penaltyNumber = "12345678901234",
     penaltyOrder = Some("01"),
     penaltyCategory = Some(LSPPenaltyCategoryEnum.Point),
@@ -489,7 +498,7 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
     lspTypeEnum = Some(LSPTypeEnum.AddedFAP)
   ), annualThreshold)(implicitly)
 
-  val summaryCardModelWithMultiplePenaltyPeriodLSPP: LateSubmissionPenaltySummaryCard = summaryCardHelper.pointSummaryCard(
+  def summaryCardModelWithMultiplePenaltyPeriodLSPP: LateSubmissionPenaltySummaryCard = summaryCardHelper.pointSummaryCard(
     LSPDetails(
       penaltyNumber = "12345678901234",
       penaltyOrder = Some("01"),
@@ -528,91 +537,95 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
       lspTypeEnum = Some(LSPTypeEnum.AddedFAP)
     ), true)(implicitly)
 
+  override def afterEach(): Unit = {
+    super.afterEach()
+    sys.props -= ShowAppealAgainstObligationChanges.name
+  }
 
   "summaryCard" when {
     "given an added point and the threshold has not been met" should {
       implicit val doc: Document = asDocument(summaryCardHtml.apply(summaryCardModelWithAddedPoint))
-      "display that the point has been added i.e. Penalty point X: adjustment point" in {
+      "display that the point has been added i.e. Penalty point X: adjustment point" in new Setup() {
         doc.select("h4").text() shouldBe "Penalty point 1: adjustment point"
       }
 
-      "display a link to allow the user to find information about adjusted points" in {
+      "display a link to allow the user to find information about adjusted points" in new Setup() {
         doc.select("a").text() shouldBe "Read the guidance about adjustment points (opens in a new tab)"
         doc.select("a").attr("href") shouldBe appConfig.adjustmentLink
       }
 
-      "display the 'active' status for an added point" in {
+      "display the 'active' status for an added point" in new Setup() {
         doc.select("strong").text() shouldBe "active"
       }
 
-      "display when the added point was added" in {
+      "display when the added point was added" in new Setup() {
         doc.select("dt").get(0).text() shouldBe "Added on"
         doc.select("dd").get(0).text() shouldBe "30 October 2069"
       }
 
-      "display when the point is due to expire" in {
+      "display when the point is due to expire" in new Setup() {
         doc.select("dt").get(1).text() shouldBe "Point due to expire"
         doc.select("dd").get(1).text() shouldBe "October 2069"
       }
 
-      "display that the user can not appeal an added point" in {
+      "display that the user can not appeal an added point" in new Setup() {
         doc.select("footer").text() shouldBe "You cannot appeal this point"
       }
     }
 
     "given an added point and the threshold has been met" should {
       implicit val doc: Document = asDocument(summaryCardHtml.apply(summaryCardModelWithAddedPointAtThreshold))
-      "display that the point has been added i.e. Penalty point X: adjustment point" in {
+      "display that the point has been added i.e. Penalty point X: adjustment point" in new Setup() {
         doc.select("h4").text() shouldBe "Penalty point 1: adjustment point"
       }
 
-      "display a link to allow the user to find information about adjusted points" in {
+      "display a link to allow the user to find information about adjusted points" in new Setup() {
         doc.select("a").text() shouldBe "Read the guidance about adjustment points (opens in a new tab)"
         doc.select("a").attr("href") shouldBe appConfig.adjustmentLink
       }
 
-      "display the 'active' status for an added point" in {
+      "display the 'active' status for an added point" in new Setup() {
         doc.select("strong").text() shouldBe "active"
       }
 
-      "display when the added point was added" in {
+      "display when the added point was added" in new Setup() {
         doc.select("dt").get(0).text() shouldBe "Added on"
         doc.select("dd").get(0).text() shouldBe "30 October 2069"
       }
 
-      "NOT display when the point is due to expire" in {
+      "NOT display when the point is due to expire" in new Setup() {
         doc.select("dt").size() shouldBe 1
         doc.select("dd").size() shouldBe 1
       }
 
-      "display that the user can not appeal an added point" in {
+      "display that the user can not appeal an added point" in new Setup() {
         doc.select("footer").text() shouldBe "You cannot appeal this point"
       }
     }
 
     "given a removed point(not FAP)" should {
       implicit val doc: Document = asDocument(summaryCardHtml.apply(summaryCardModelWithRemovedPoint))
-      "display that the point number as usual" in {
+      "display that the point number as usual" in new Setup() {
         doc.select("h4").text() shouldBe "Penalty point"
       }
 
-      "display the VAT period the point was removed from" in {
+      "display the VAT period the point was removed from" in new Setup() {
         doc.select("dt").get(0).text() shouldBe "VAT period"
         doc.select("dd").get(0).text() shouldBe "1 January 2020 to 1 February 2020"
       }
 
-      "display the reason why the point was removed" in {
+      "display the reason why the point was removed" in new Setup() {
         doc.select("dt").get(1).text() shouldBe "Reason"
         doc.select("dd").get(1).text() shouldBe "Removed by HMRC"
       }
 
-      "not display any footer text" in {
+      "not display any footer text" in new Setup() {
         doc.select("footer li").hasText shouldBe false
       }
     }
 
     "given a removed point (FAP)" should {
-      "display the reason why the point was removed (if reason was FAP)" in {
+      "display the reason why the point was removed (if reason was FAP)" in new Setup() {
         implicit val doc: Document = asDocument(summaryCardHtml.apply(summaryCardModelWithRemovedPointFilingFrequencyChange))
         doc.select("dt").get(1).text() shouldBe "Reason"
         doc.select("dd").get(1).text() shouldBe "Change to VAT return deadlines"
@@ -620,18 +633,25 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
     }
 
     "given a point - return not submitted" should {
-      val docWithPoint: Document =
-        asDocument(summaryCardHtml.apply(summaryCardModelNoReturnSubmitted))
 
-      "have an hidden span" in {
+      "have a hidden span for check if you can appeal" in new Setup() {
+        val docWithPoint: Document = asDocument(summaryCardHtml.apply(summaryCardModelNoReturnSubmitted))
         docWithPoint.select(".app-summary-card__footer a").get(0).ownText() shouldBe "Check if you can appeal"
         docWithPoint.select(".app-summary-card__footer span").text() shouldBe "penalty point 1"
+      }
+
+      "have a hidden span for find out how to appeal (ShowAppealAgainstObligationChanges feature enabled)" in new Setup(
+        isShowAppealAgainstObligationChangesEnabled = true
+      ) {
+        val docWithPointFSEnabled: Document = asDocument(summaryCardHtml.apply(summaryCardModelNoReturnSubmitted))
+        docWithPointFSEnabled.select(".app-summary-card__footer a").get(0).ownText() shouldBe "Find out how to appeal"
+        docWithPointFSEnabled.select(".app-summary-card__footer span").text() shouldBe "penalty point 1"
       }
 
     }
 
     "given a financial point" should {
-      val docWithThresholdPenalty: Document =
+      def docWithThresholdPenalty: Document =
         asDocument(summaryCardHtml.apply(summaryCardModelWithThresholdPenalty))
       val docWithFinancialLSP: Document =
         asDocument(summaryCardHtml.apply(summaryCardModelWithFinancialLSP(true)))
@@ -644,39 +664,46 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
       val docWithFinancialPointAppealTribunalRejected: Document =
         asDocument(summaryCardHtml.apply(summaryCardModelWithFinancialPointBelowThresholdAndAppealTribunalRejected))
 
-      "shows the financial heading with point number when the point is below/at threshold for filing frequency" in {
+      "shows the financial heading with point number when the point is below/at threshold for filing frequency" in new Setup() {
         docWithThresholdPenalty.select(".app-summary-card__title").get(0).text() shouldBe "Penalty point 1: £200 penalty"
       }
 
-      "shows the financial heading WITHOUT point number when the point is above threshold for filing frequency and a rewording of the appeal text" in {
+      "shows the financial heading WITHOUT point number when the point is above threshold for filing frequency and a rewording of the appeal text" in new Setup() {
         docWithFinancialLSP.select(".app-summary-card__title").get(0).ownText() shouldBe "£200 penalty"
         docWithFinancialLSP.select(".app-summary-card__title span").get(0).ownText() shouldBe "for late submission of VAT due on 30 October 2069"
         docWithFinancialLSP.select(".app-summary-card__footer a").get(0).ownText() shouldBe "Appeal this penalty"
         docWithFinancialLSP.select(".app-summary-card__footer span").get(0).text() shouldBe "for late VAT return due on 30 October 2069"
       }
 
-      "shows the appeal information when the point is being appealed - i.e. under review" in {
+      "shows the appeal information when the point is being appealed - i.e. under review" in new Setup() {
         docWithFinancialPointAppealUnderReview.select("dt").get(3).text() shouldBe "Appeal status"
         docWithFinancialPointAppealUnderReview.select("dd").get(3).text() shouldBe "Under review by HMRC"
       }
 
-      "have the appeal status for REJECTED" in {
+      "have the appeal status for REJECTED" in new Setup() {
         docWithFinancialPointAppealRejected.select("dt").get(3).text() shouldBe "Appeal status"
         docWithFinancialPointAppealRejected.select("dd").get(3).text() shouldBe "Appeal rejected"
       }
 
-      "have the appeal status for UNDER_TRIBUNAL_REVIEW" in {
+      "have the appeal status for UNDER_TRIBUNAL_REVIEW" in new Setup() {
         docWithFinancialPointAppealUnderTribunalReview.select("dt").get(3).text() shouldBe "Appeal status"
         docWithFinancialPointAppealUnderTribunalReview.select("dd").get(3).text() shouldBe "Under review by the tax tribunal"
       }
 
-      "have the appeal status for TRIBUNAL REJECTED" in {
+      "have the appeal status for TRIBUNAL REJECTED" in new Setup() {
         docWithFinancialPointAppealTribunalRejected.select("dt").get(3).text() shouldBe "Appeal status"
         docWithFinancialPointAppealTribunalRejected.select("dd").get(3).text() shouldBe "Appeal rejected by tax tribunal"
       }
 
-      "display check if you can appeal link if the penalty is unappealable" in {
+      "display check if you can appeal link if the penalty is unappealable" in new Setup() {
         docWithThresholdPenalty.select(".app-summary-card__footer a").text() shouldBe "Check if you can appeal"
+        docWithThresholdPenalty.select("dt").eq(3).isEmpty shouldBe true
+      }
+
+      "display find out how to appeal link if the penalty is unappealable (ShowAppealAgainstObligationChanges feature enabled)" in new Setup(
+        isShowAppealAgainstObligationChangesEnabled = true
+      ) {
+        docWithThresholdPenalty.select(".app-summary-card__footer a").text() shouldBe "Find out how to appeal"
         docWithThresholdPenalty.select("dt").eq(3).isEmpty shouldBe true
       }
     }
@@ -690,40 +717,40 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
       val docWithAppealedPointUnderTribunalRejected: Document = asDocument(summaryCardHtml.apply(summaryCardModelWithAppealedPointTribunalRejected))
 
 
-      "not show the appeal link" in {
+      "not show the appeal link" in new Setup() {
         docWithAppealedPoint.select(".app-summary-card__footer a").isEmpty shouldBe true
       }
 
-      "have the appeal status for UNDER_REVIEW" in {
+      "have the appeal status for UNDER_REVIEW" in new Setup() {
         docWithAppealedPoint.select("dt").get(3).text() shouldBe "Appeal status"
         docWithAppealedPoint.select("dd").get(3).text() shouldBe "Under review by HMRC"
       }
 
-      "have the appeal status for UNDER_TRIBUNAL_REVIEW" in {
+      "have the appeal status for UNDER_TRIBUNAL_REVIEW" in new Setup() {
         docWithAppealedPointUnderTribunalReview.select("dt").get(3).text() shouldBe "Appeal status"
         docWithAppealedPointUnderTribunalReview.select("dd").get(3).text() shouldBe "Under review by the tax tribunal"
       }
 
-      "have the appeal status for ACCEPTED - removing the point due to expire and point number" in {
+      "have the appeal status for ACCEPTED - removing the point due to expire and point number" in new Setup() {
         docWithAppealedPointAccepted.select("dt").text().contains("Point due to expire") shouldBe false
         docWithAppealedPointAccepted.select("dt").get(3).text() shouldBe "Appeal status"
         docWithAppealedPointAccepted.select("dd").get(3).text() shouldBe "Appeal accepted"
         docWithAppealedPointAccepted.select("h4").get(0).text() shouldBe "Penalty"
       }
 
-      "have the appeal status for ACCEPTED_BY_TRIBUNAL - removing the point due to expire and point number" in {
+      "have the appeal status for ACCEPTED_BY_TRIBUNAL - removing the point due to expire and point number" in new Setup() {
         docWithAppealedPointAcceptedByTribunal.select("dt").text().contains("Point due to expire") shouldBe false
         docWithAppealedPointAcceptedByTribunal.select("dt").get(3).text() shouldBe "Appeal status"
         docWithAppealedPointAcceptedByTribunal.select("dd").get(3).text() shouldBe "Appeal accepted by tax tribunal"
         docWithAppealedPointAcceptedByTribunal.select("h4").get(0).text() shouldBe "Penalty"
       }
 
-      "have the appeal status for REJECTED" in {
+      "have the appeal status for REJECTED" in new Setup() {
         docWithAppealedPointRejected.select("dt").get(3).text() shouldBe "Appeal status"
         docWithAppealedPointRejected.select("dd").get(3).text() shouldBe "Appeal rejected"
       }
 
-      "have the appeal status for TRIBUNAL REJECTED" in {
+      "have the appeal status for TRIBUNAL REJECTED" in new Setup() {
         docWithAppealedPointUnderTribunalRejected.select("dt").get(3).text() shouldBe "Appeal status"
         docWithAppealedPointUnderTribunalRejected.select("dd").get(3).text() shouldBe "Appeal rejected by tax tribunal"
       }
@@ -731,49 +758,75 @@ class LateSubmissionPenaltySummaryCardSpec extends SpecBase with ViewBehaviours 
 
     "given multiple penalty period in LSP" should {
       implicit val doc: Document = asDocument(summaryCardHtml.apply(summaryCardModelWithMultiplePenaltyPeriodLSP))
-      "show message VAT return submitted earlier in multiple penalty period" in {
+      "show message VAT return submitted earlier in multiple penalty period" in new Setup() {
         doc.select("p.govuk-body").text() shouldBe "The VAT Return due on 24 May 2021 was also submitted late. HMRC only applies 1 penalty for late submission in each month."
       }
     }
 
     "given multiple penalty period in LSPP" should {
       implicit val doc: Document = asDocument(summaryCardHtml.apply(summaryCardModelWithMultiplePenaltyPeriodLSPP))
-      "show message VAT return submitted earlier in multiple penalty period" in {
+      "show message VAT return submitted earlier in multiple penalty period" in new Setup() {
         doc.select("p.govuk-body").text() shouldBe "The VAT Return due on 24 May 2021 was also submitted late. HMRC only applies 1 penalty for late submission in each month."
       }
     }
 
     "given no multiple penalty period in LSP" should {
-      implicit val doc: Document = asDocument(summaryCardHtml.apply(summaryCardModelWithFinancialLSP(false)))
+      implicit def doc: Document = asDocument(summaryCardHtml.apply(summaryCardModelWithFinancialLSP(false)))
       val docSubmitted: Document = asDocument(summaryCardHtml.apply(summaryCardModelWithFinancialLSP(true)))
-      "no message relating to multiple penalties in the same period should appear" in {
+      "no message relating to multiple penalties in the same period should appear" in new Setup() {
         doc.select("p.govuk-body").text().isEmpty shouldBe true
       }
 
-      "set the correct hidden span for a lurking point with no return submitted" in {
+      "set the correct hidden span for a lurking point with no return submitted" in new Setup() {
         doc.select("a").get(0).ownText() shouldBe "Check if you can appeal"
         doc.select("a span").get(0).text() shouldBe "for penalty on late VAT return due 30 October 2069"
       }
 
-      "set the correct hidden span for a lurking point with a return submitted" in {
+      "set the correct hidden span for a lurking point with no return submitted (ShowAppealAgainstObligationChanges feature enabled)" in new Setup(
+        isShowAppealAgainstObligationChangesEnabled = true
+      ) {
+        implicit val doc: Document = asDocument(summaryCardHtml.apply(summaryCardModelWithFinancialLSP(false)))
+        doc.select("a").get(0).ownText() shouldBe "Find out how to appeal"
+        doc.select("a span").get(0).text() shouldBe "for penalty on late VAT return due 30 October 2069"
+      }
+
+      "set the correct hidden span for a lurking point with a return submitted" in new Setup() {
         docSubmitted.select("a").get(0).ownText() shouldBe "Appeal this penalty"
         docSubmitted.select("a span").get(0).text() shouldBe "for late VAT return due on 30 October 2069"
       }
     }
 
     "given a non-appealed point and it is unappealable" should {
-      implicit val doc: Document = asDocument(summaryCardHtml.apply(summaryCardModelUnappealable))
-      "not show the appeal status row and have the check if you can appeal link" in {
+      implicit def doc: Document = asDocument(summaryCardHtml.apply(summaryCardModelUnappealable))
+      "not show the appeal status row and have the check if you can appeal link" in new Setup() {
         doc.select(".app-summary-card__footer a").get(0).ownText() shouldBe "Check if you can appeal"
+        doc.select(".app-summary-card__footer a span").text() shouldBe "for late VAT return due on 12 March 2021"
+        doc.select("dt").eq(4).isEmpty shouldBe true
+      }
+
+      "not show the appeal status row and have the find out how to appeal link (ShowAppealAgainstObligationChanges feature enabled)" in new Setup(
+        isShowAppealAgainstObligationChangesEnabled = true
+      ) {
+        implicit val doc: Document = asDocument(summaryCardHtml.apply(summaryCardModelUnappealable))
+        doc.select(".app-summary-card__footer a").get(0).ownText() shouldBe "Find out how to appeal"
         doc.select(".app-summary-card__footer a span").text() shouldBe "for late VAT return due on 12 March 2021"
         doc.select("dt").eq(4).isEmpty shouldBe true
       }
     }
 
     "given a non-appealed point and it is unappealable, with an empty appeal level" should {
-      implicit val doc: Document = asDocument(summaryCardHtml.apply(summaryCardModelUnappealable.copy(appealLevel = None)))
-      "not show the appeal status row and have the check if you can appeal link" in {
+      implicit def doc: Document = asDocument(summaryCardHtml.apply(summaryCardModelUnappealable.copy(appealLevel = None)))
+      "not show the appeal status row and have the check if you can appeal link" in new Setup() {
         doc.select(".app-summary-card__footer a").get(0).ownText() shouldBe "Check if you can appeal"
+        doc.select(".app-summary-card__footer a span").text() shouldBe "for late VAT return due on 12 March 2021"
+        doc.select("dt").eq(4).isEmpty shouldBe true
+      }
+
+      "not show the appeal status row and have the find out how to appeal link (ShowAppealAgainstObligationChanges feature enabled)" in new Setup(
+        isShowAppealAgainstObligationChangesEnabled = true
+      ) {
+        implicit val doc: Document = asDocument(summaryCardHtml.apply(summaryCardModelUnappealable.copy(appealLevel = None)))
+        doc.select(".app-summary-card__footer a").get(0).ownText() shouldBe "Find out how to appeal"
         doc.select(".app-summary-card__footer a span").text() shouldBe "for late VAT return due on 12 March 2021"
         doc.select("dt").eq(4).isEmpty shouldBe true
       }


### PR DESCRIPTION
Feature switch added

Lots of this can be reverted once the feature switch is removed (i.e., def's back to val's, summary card viewmodel reverted etc.)

QA: https://github.com/hmrc/app-config-qa/pull/20719
Staging: https://github.com/hmrc/app-config-staging/pull/14260
Prod: https://github.com/hmrc/app-config-production/pull/20494