### PR TITLE
Increase debug level logs to error level to improve error investigations

### DIFF
--- a/app/connectors/httpParsers/ComplianceDataParser.scala
+++ b/app/connectors/httpParsers/ComplianceDataParser.scala
@@ -55,7 +55,7 @@ object ComplianceDataParser {
               Right(CompliancePayloadSuccessResponse(compliancePayload))
             case JsError(errors) =>
               PagerDutyHelper.log("CompliancePayloadReads", INVALID_JSON_RECEIVED_FROM_PENALTIES_BACKEND)
-              logger.debug(s"[CompliancePayloadReads][read] Json validation errors: $errors")
+              logger.error(s"[CompliancePayloadReads][read] Json validation errors: $errors")
               Left(CompliancePayloadMalformed)
           }
         case NOT_FOUND => {

--- a/app/connectors/httpParsers/GetPenaltyDetailsParser.scala
+++ b/app/connectors/httpParsers/GetPenaltyDetailsParser.scala
@@ -35,12 +35,10 @@ object GetPenaltyDetailsParser {
             case JsSuccess(model, _) =>
               logger.info("[GetPenaltyDetailsResponseReads][read]: Successful call to retrieve penalties details.")
               Right(model)
-            case failure => {
-              logger.debug(s"[GetPenaltyDetailsResponseReads][read]: Failed to parse to model - failures: $failure")
-              logger.error("[GetPenaltyDetailsResponseReads][read]: Failed to parse to model")
+            case failure =>
+              logger.error(s"[GetPenaltyDetailsResponseReads][read]: Failed to parse to model - failures: $failure")
               PagerDutyHelper.log("PenaltiesConnectorParser: GetPenaltyDetailsResponseReads", INVALID_JSON_RECEIVED_FROM_PENALTIES_BACKEND)
               Left(InvalidJson)
-            }
           }
         case NO_CONTENT =>
           logger.info(s"[GetPenaltyDetailsResponseReads][read]: No content found for VRN provided, returning empty model")
@@ -49,7 +47,8 @@ object GetPenaltyDetailsParser {
           logger.error(s"[GetPenaltyDetailsResponseReads][read]: Bad request returned with reason: ${response.body}")
           PagerDutyHelper.log("PenaltiesConnectorParser: GetPenaltyDetailsResponseReads", RECEIVED_4XX_FROM_PENALTIES_BACKEND)
           Left(BadRequest)
-        case status => logger.error(s"[GetPenaltyDetailsResponseReads][read]: Unexpected response, status $status returned with reason: ${response.body}")
+        case status =>
+          logger.error(s"[GetPenaltyDetailsResponseReads][read]: Unexpected response, status $status returned with reason: ${response.body}")
           PagerDutyHelper.logStatusCode("PenaltiesConnectorParser: GetPenaltyDetailsResponseReads", status)(
             RECEIVED_4XX_FROM_PENALTIES_BACKEND, RECEIVED_5XX_FROM_PENALTIES_BACKEND)
           Left(UnexpectedFailure(status, s"Unexpected response, status $status returned"))

--- a/app/controllers/predicates/AuthPredicate.scala
+++ b/app/controllers/predicates/AuthPredicate.scala
@@ -67,7 +67,7 @@ class AuthPredicate @Inject()(override val messagesApi: MessagesApi,
         Future.successful(errorHandler.showInternalServerError())
     } recover {
       case _: NoActiveSession =>
-        logger.debug(s"$logMsgStart - No active session, redirect to GG sign in")
+        logger.info(s"$logMsgStart - No active session, redirect to GG sign in")
         Redirect(appConfig.signInUrl)
       case _: AuthorisationException =>
         logger.warn(s"$logMsgStart - Unauthorised exception, redirect to GG sign in")
@@ -105,20 +105,20 @@ class AuthPredicate @Inject()(override val messagesApi: MessagesApi,
               } match {
                 case Some(arn) => block(User(vrn, arn = Some(arn)))
                 case None =>
-                  logger.debug("[AuthPredicate][authoriseAsAgent] - Agent with no HMRC-AS-AGENT enrolment. Rendering unauthorised view.")
+                  logger.info("[AuthPredicate][authoriseAsAgent] - Agent with no HMRC-AS-AGENT enrolment. Rendering unauthorised view.")
                   Future.successful(Forbidden(unauthorisedView()))
               }
           } recover {
           case _: NoActiveSession =>
-            logger.debug(s"AgentPredicate][authoriseAsAgent] - No active session. Redirecting to ${appConfig.signInUrl}")
+            logger.info(s"AgentPredicate][authoriseAsAgent] - No active session. Redirecting to ${appConfig.signInUrl}")
             Redirect(appConfig.signInUrl)
           case _: AuthorisationException =>
-            logger.debug(s"[AgentPredicate][authoriseAsAgent] - Agent does not have delegated authority for client. " +
+            logger.info(s"[AgentPredicate][authoriseAsAgent] - Agent does not have delegated authority for client. " +
               s"Showing unauthorised")
             Forbidden(unauthorisedView())
         }
       case None =>
-        logger.debug(s"[AuthPredicate][authoriseAsAgent] - No Client VRN in session. Redirecting to ${appConfig.agentClientLookupStartUrl(request.uri)}")
+        logger.info(s"[AuthPredicate][authoriseAsAgent] - No Client VRN in session. Redirecting to ${appConfig.agentClientLookupStartUrl(request.uri)}")
         Future.successful(Redirect(appConfig.agentClientLookupStartUrl(request.uri)))
     }
   }

--- a/app/viewmodels/IndexPageHelper.scala
+++ b/app/viewmodels/IndexPageHelper.scala
@@ -217,7 +217,7 @@ class IndexPageHelper @Inject()(p: views.html.components.p,
     complianceService.getDESComplianceData(vrn)(implicitly, implicitly, implicitly, pocAchievementDate).map {
       _.fold[Either[Result, CompliancePayload]](
         {
-          logger.debug(s"[IndexPageHelper][callObligationAPI] - Received error when calling the Obligation API")
+          logger.error(s"[IndexPageHelper][callObligationAPI] - Received error when calling the Obligation API")
           Left(errorHandler.showInternalServerError(Some(user)))
         })(
         Right(_)


### PR DESCRIPTION
.debug logs do not appear in kibana.
We should use .error, .warn or .info for useful logs. 
User data cannot be displayed in these levels, so can be left with .debug level logs for user data.